### PR TITLE
deps: get rid of old dependency

### DIFF
--- a/console-program.cabal
+++ b/console-program.cabal
@@ -1,5 +1,5 @@
 name:            console-program
-version:         0.5.0
+version:         0.6.0
 cabal-Version:   >= 1.10
 license:         BSD3
 author:          Arie Peterson
@@ -52,7 +52,7 @@ library
     utility-ht == 0.0.*,
     split == 0.2.*,
     parsec == 3.1.*,
-    parsec-extra == 0.2.*
+    mtl >= 2.2.1
   if !os(windows)
     build-depends:
       unix >= 2.7

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,14 +43,9 @@ packages: [.]
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
 #
-extra-deps:
-  - parsec-extra-0.2.0.0@sha256:47f16e5d00cb62db52d126903787dcccc94d500cfbcb54316f5db00f31da4fa2,735
-
+# extra-deps:
 # Override default flag values for local packages and extra-deps
 # flags: {}
-flags:
-  mintty:
-    Win32-2-13-1: false
 
 # Extra package databases containing global packages
 # extra-package-dbs: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,14 +3,7 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: parsec-extra-0.2.0.0@sha256:47f16e5d00cb62db52d126903787dcccc94d500cfbcb54316f5db00f31da4fa2,735
-    pantry-tree:
-      sha256: 8d8d15ac5aca977855d1fe89f3f23ecbbddc604e3cb887af5c27b540dba49ffc
-      size: 225
-  original:
-    hackage: parsec-extra-0.2.0.0@sha256:47f16e5d00cb62db52d126903787dcccc94d500cfbcb54316f5db00f31da4fa2,735
+packages: []
 snapshots:
 - completed:
     sha256: abcc4a65c15c7c2313f1a87f01bfd4d910516e1930b99653eef1d2d006515916


### PR DESCRIPTION
Without that it will be harder to update to GHC 9.6.3